### PR TITLE
Refactor startup config

### DIFF
--- a/HttpConfig/Bristech.Srm.HttpConfig/AssemblyInfo.fs
+++ b/HttpConfig/Bristech.Srm.HttpConfig/AssemblyInfo.fs
@@ -34,8 +34,8 @@ open System.Runtime.InteropServices
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [<assembly: AssemblyVersion("1.0.*")>]
-[<assembly: AssemblyVersion("0.1.4.0")>]
-[<assembly: AssemblyFileVersion("0.1.4.0")>]
+[<assembly: AssemblyVersion("0.1.5.0")>]
+[<assembly: AssemblyFileVersion("0.1.5.0")>]
 
 do
     ()

--- a/HttpConfig/Bristech.Srm.HttpConfig/Startup.fs
+++ b/HttpConfig/Bristech.Srm.HttpConfig/Startup.fs
@@ -3,12 +3,13 @@
 open Owin
 open System.Web.Http
 
+module Default = 
+    let config =
+        new HttpConfiguration()
+        |> Logging.configure
+        |> Cors.configure
+        |> Routes.configure
+        |> Serialization.configure
+
 type Startup() =
-    member __.Configuration (appBuilder: IAppBuilder) =
-        let config =
-            new HttpConfiguration()
-            |> Logging.configure
-            |> Cors.configure
-            |> Routes.configure
-            |> Serialization.configure
-        appBuilder.UseWebApi(config) |> ignore
+    member __.Configuration (appBuilder: IAppBuilder) = appBuilder.UseWebApi(Default.config) |> ignore


### PR DESCRIPTION
Split the default config out so that further configuration can be done, if required. 